### PR TITLE
complete class added to whole idea, line-through added to just title …

### DIFF
--- a/lib/2-do-box.js
+++ b/lib/2-do-box.js
@@ -4,22 +4,36 @@ var storage = getLocalStorage() || [];
 renderLocalStorageToPage();
 
 var upQualities = {
-  'swill': 'plausible',
-  'plausible': 'genius',
-  'genius' : 'genius'
+  'none': 'low',
+  'low': 'normal',
+  'normal' : 'high',
+  'high' : 'critical',
+  'critical' : 'critical'
 };
 
 var downQualities = {
-  'genius': 'plausible',
-  'plausible': 'swill',
-  'swill' : 'swill'
+  'critical': 'high',
+  'high': 'normal',
+  'normal' : 'low',
+  'low' : 'none',
+  'none' : 'none'
 };
+
+$(document).ready(function() {
+  $('.complete').hide();
+  debugger
+  sortIdeas();
+});
+
+$('.show-completed').on('click', function() {
+  $('.complete').show();
+});
 
 function Idea(title, body){
   this.title = title;
   this.body = body;
   this.id = Date.now();
-  this.quality = 'swill';
+  this.quality = 'none';
   this.completion = 'new';
 }
 
@@ -110,14 +124,16 @@ function editBody(id, newBody, idea) {
   localStorage.setItem('list', JSON.stringify(storage));
 }
 
-// $(document).ready(function() {
-//   $('.complete').hide();
-// });
-//
-// $('.show-completed').on('click', function() {
-//   $('.complete').show();
-//
-// });
+function sortIdeas() {
+storage.sort(function(idea) {
+
+  if (idea.completion === "complete") {
+    return 1;
+  }
+});
+}
+
+
 
 $('.title-input').on('click', function() {
   clearField($('.title-input'));

--- a/lib/2-do-box.js
+++ b/lib/2-do-box.js
@@ -3,50 +3,17 @@ var $ = require("jquery");
 var storage = getLocalStorage() || [];
 renderLocalStorageToPage();
 
-$(document).ready(function() {
-  $('.complete').hide();
-});
+var upQualities = {
+  'swill': 'plausible',
+  'plausible': 'genius',
+  'genius' : 'genius'
+};
 
-$('.show-completed').on('click', function() {
-  $('.complete').show();
-
-  //add function that updates local storage with idea-list so that class additions are saved
-});
-
-
-
-$('.save-btn').on('click', function() {
-  var $title = $('.title-input').val();
-  var $body = $('.body-input').val();
-  makeIdeaList($title, $body);
-  clearField($('.title-input'));
-  clearField($('.body-input'));
-});
-
-
-function clearField(element) {
-  if (element.val !== "") {
-    element.val('');
-  }
-}
-
-$('.title-input').on('click', function() {
-  clearField($('.title-input'));
-});
-
-$('.body-input').on('click', function() {
-  clearField($('.body-input'));
-});
-
-function renderLocalStorageToPage() {
-  storage.forEach(function(idea) {
-    appendIdea(idea);
-  });
-}
-
-function getLocalStorage() {
-  return JSON.parse(localStorage.getItem('list'));
-}
+var downQualities = {
+  'genius': 'plausible',
+  'plausible': 'swill',
+  'swill' : 'swill'
+};
 
 function Idea(title, body){
   this.title = title;
@@ -56,9 +23,36 @@ function Idea(title, body){
   this.completion = 'new';
 }
 
+function renderLocalStorageToPage() {  //rename this function?
+  storage.forEach(function(idea) {
+    appendIdea(idea);
+  });
+}
+
+function getLocalStorage() {
+  return JSON.parse(localStorage.getItem('list'));
+}
+
+function findIdea(id) {
+ return storage.find(function(idea) {
+    return idea.id === id;
+  });
+}
+
+function addCompleteClass() {
+  var item = $(this).parent().parent();
+  item.addClass('complete');
+}
+
+function clearField(element) {
+  if (element.val !== "") {
+    element.val('');
+  }
+}
+
 function appendIdea(idea) {
   return $('.idea-list').prepend(`
-      <li class="idea" class= ${idea.completion} id= ${idea.id}>
+      <li class="idea ${idea.completion}"  id= ${idea.id}>
         <div class='first-line'>
           <span contenteditable class="title edit-title edit-content search">${idea.title}</span>
           <button type="button" class="delete-btn">Delete</button>
@@ -81,6 +75,13 @@ function makeIdeaList(title, body) {
   appendIdea(idea);
 }
 
+function removeIdea(id) {
+    var id = parseInt(id);
+    storage = storage.filter(function(idea) {
+      return idea.id != id;
+  });
+}
+
 function changeQuality(id, newQuality, idea) {
   id = parseInt(id);
   var idea = findIdea(id);
@@ -88,57 +89,11 @@ function changeQuality(id, newQuality, idea) {
   localStorage.setItem('list', JSON.stringify(storage));
 }
 
-
 function changeComplete(id, idea) {
   id = parseInt(id);
   var idea = findIdea(id);
   idea.completion = 'complete';
   localStorage.setItem('list', JSON.stringify(storage));
-}
-
-$('.idea-list').on('click', '.completed-btn',  function() {
-    addCompleteClass.bind(this)()
-    var id = $(this).parents('.idea').attr('id');
-    changeComplete(id)
-});
-
-function addCompleteClass() {
-  var item = $(this).parent().parent()
-  item.addClass('complete');
-}
-
-var upQualities = {
-  'swill': 'plausible',
-  'plausible': 'genius',
-  'genius' : 'genius'
-};
-
-$('.idea-list').on('click', '.up-btn',  function() {
-    var $quality = $(this).siblings('span').children();
-    var newQuality = upQualities[$quality.text()];
-    $quality.text(newQuality);
-    var id = $(this).parents('.idea').attr('id');
-    changeQuality(id, newQuality);
-});
-
-var downQualities = {
-  'genius': 'plausible',
-  'plausible': 'swill',
-  'swill' : 'swill'
-};
-
-$('.idea-list').on('click', '.down-btn', function() {
-    var $quality = $(this).siblings('span').children();
-    var newQuality = downQualities[$quality.text()];
-    $quality.text(newQuality);
-    var id = $(this).parents('.idea').attr('id');
-    changeQuality(id, newQuality);
-});
-
-function findIdea(id) {
- return storage.find(function(idea) {
-    return idea.id === id;
-  });
 }
 
 function editTitle(id, newTitle, idea) {
@@ -148,18 +103,66 @@ function editTitle(id, newTitle, idea) {
   localStorage.setItem('list', JSON.stringify(storage));
 }
 
-$('.idea-list').on('focusout', '.edit-title', function() {
-  var id = $(this).parents('.idea').attr('id');
-  var newTitle = $(this).text();
-  editTitle(id, newTitle);
-});
-
 function editBody(id, newBody, idea) {
   id = parseInt(id);
   var idea = findIdea(id);
   idea.body = newBody;
   localStorage.setItem('list', JSON.stringify(storage));
 }
+
+// $(document).ready(function() {
+//   $('.complete').hide();
+// });
+//
+// $('.show-completed').on('click', function() {
+//   $('.complete').show();
+//
+// });
+
+$('.title-input').on('click', function() {
+  clearField($('.title-input'));
+});
+
+$('.body-input').on('click', function() {
+  clearField($('.body-input'));
+});
+
+$('.save-btn').on('click', function() {
+  var $title = $('.title-input').val();
+  var $body = $('.body-input').val();
+  makeIdeaList($title, $body);
+  clearField($('.title-input'));
+  clearField($('.body-input'));
+});
+
+$('.idea-list').on('click', '.completed-btn',  function() {
+    addCompleteClass.bind(this)();
+
+    var id = $(this).parents('.idea').attr('id');
+    changeComplete(id);
+});
+
+$('.idea-list').on('click', '.up-btn',  function() {
+    var $quality = $(this).siblings('span').children();
+    var newQuality = upQualities[$quality.text()];
+    $quality.text(newQuality);
+    var id = $(this).parents('.idea').attr('id');
+    changeQuality(id, newQuality);
+});
+
+$('.idea-list').on('click', '.down-btn', function() {
+    var $quality = $(this).siblings('span').children();
+    var newQuality = downQualities[$quality.text()];
+    $quality.text(newQuality);
+    var id = $(this).parents('.idea').attr('id');
+    changeQuality(id, newQuality);
+});
+
+$('.idea-list').on('focusout', '.edit-title', function() {
+  var id = $(this).parents('.idea').attr('id');
+  var newTitle = $(this).text();
+  editTitle(id, newTitle);
+});
 
 $('.idea-list').on('focusout', '.edit-body', function() {
   var id = $(this).parents('.idea').attr('id');
@@ -175,7 +178,6 @@ $('.idea-list').keypress(function(event) {
     }, 10);
   }
 });
-
 
 $('.search-input').on('keyup', function(event) {
   event.preventDefault();
@@ -193,13 +195,6 @@ $('.search-input').on('keyup', function(event) {
 $('.search-input').on('click', function() {
   clearField($('.search-input'));
 });
-
-function removeIdea(id) {
-    var id = parseInt(id);
-    storage = storage.filter(function(idea) {
-      return idea.id != id;
-  });
-}
 
 $('.idea-list').on('click', '.delete-btn', function() {
   var id = $(this).parent().parent().attr('id');

--- a/lib/2-do-box.js
+++ b/lib/2-do-box.js
@@ -9,6 +9,8 @@ $(document).ready(function() {
 
 $('.show-completed').on('click', function() {
   $('.complete').show();
+
+  //add function that updates local storage with idea-list so that class additions are saved
 });
 
 
@@ -94,17 +96,22 @@ function changeComplete(id, idea) {
   localStorage.setItem('list', JSON.stringify(storage));
 }
 
-var upQualities = {
-    'swill': 'plausible',
-    'plausible': 'genius',
-    'genius' : 'genius'
-};
-
 $('.idea-list').on('click', '.completed-btn',  function() {
-    $(this).parent().parent().addClass('complete');
+    addCompleteClass.bind(this)()
     var id = $(this).parents('.idea').attr('id');
     changeComplete(id)
 });
+
+function addCompleteClass() {
+  var item = $(this).parent().parent()
+  item.addClass('complete');
+}
+
+var upQualities = {
+  'swill': 'plausible',
+  'plausible': 'genius',
+  'genius' : 'genius'
+};
 
 $('.idea-list').on('click', '.up-btn',  function() {
     var $quality = $(this).siblings('span').children();

--- a/lib/styles.css
+++ b/lib/styles.css
@@ -114,6 +114,6 @@ li {
   }
 }
 
-.complete {
+.complete .first-line {
   text-decoration: line-through;
 }


### PR DESCRIPTION
Right now the complete class is added to the whole idea that is selected, and then the line-through text decoration is added to just the title through CSS. We still need to work on getting the class addition to save after reloading. I think if we create a function in document.ready that updates local storage with idea-list, it may do that.
